### PR TITLE
Add Jekyll with Minimal Mistakes dark theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+
+group :jekyll_plugins do
+  gem "jekyll-remote-theme"
+  gem "jekyll-include-cache"
+  gem "jekyll-feed"
+  gem "jekyll-sitemap"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,64 @@
+title: "Jacopo Biscella"
+subtitle: "Engineering Notes & Knowledge Sharing"
+name: "Jacopo Biscella"
+description: "Personal notes on software engineering, system architecture, and testing."
+url: "https://www.jacopobiscella.net"
+baseurl: ""
+repository: "jbiscella/www.jacopobiscella.net"
+
+remote_theme: "mmistakes/minimal-mistakes@4.26.2"
+minimal_mistakes_skin: "dark"
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-feed
+  - jekyll-sitemap
+  - jekyll-include-cache
+
+author:
+  name: "Jacopo Biscella"
+  bio: "Experienced IT professional based in London. Sharing notes on engineering and leadership."
+  location: "London, UK"
+  links:
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/jacopobiscella/"
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/jbiscella"
+
+# Apply default layout to all pages with front matter
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "single"
+      author_profile: true
+      toc: true
+      toc_sticky: true
+
+# Navigation
+navigation:
+  main:
+    - title: "Notes"
+      children:
+        - title: "Circuit Breakers"
+          url: /circuit-breakers/main/
+        - title: "Contract Testing"
+          url: /contract-testing/main/
+        - title: "Smoke Testing"
+          url: /smoke-testing/main/
+        - title: "System Architecture"
+          url: /system-architecture/main/
+        - title: "Web Services & REST"
+          url: /web-services/main/
+    - title: "CV"
+      url: /cv_setl_english.html
+
+# Exclude files not to be processed by Jekyll
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+  - "*.puml"
+  - README.md

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,15 @@
+main:
+  - title: "Notes"
+    children:
+      - title: "Circuit Breakers"
+        url: /circuit-breakers/main/
+      - title: "Contract Testing"
+        url: /contract-testing/main/
+      - title: "Smoke Testing"
+        url: /smoke-testing/main/
+      - title: "System Architecture"
+        url: /system-architecture/main/
+      - title: "Web Services & REST"
+        url: /web-services/main/
+  - title: "CV"
+    url: /cv_setl_english.html

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,3 +1,11 @@
+---
+layout: single
+title: "Introduction to Circuit Breakers"
+author_profile: true
+toc: true
+toc_sticky: true
+---
+
 ### **Introduction to Circuit Breakers**
 
 ---

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,3 +1,11 @@
+---
+layout: single
+title: "Introduction to Contract Testing"
+author_profile: true
+toc: true
+toc_sticky: true
+---
+
 # **Introduction to Contract Testing**
 
 ---

--- a/index.md
+++ b/index.md
@@ -1,0 +1,34 @@
+---
+layout: single
+title: "Welcome"
+author_profile: true
+toc: false
+---
+
+## About Me
+
+I am Jacopo Biscella, an experienced IT professional currently working in London.
+
+## Knowledge Sharing
+
+On this website you'll find my personal notes and knowledge, shared as a courtesy to facilitate knowledge-sharing with collaborators and anyone seeking insights in the fields of engineering and leadership.
+
+> **Note:** These notes have been partially processed with AI and are not necessarily reviewed in depth.
+
+## Notes
+
+| Topic | Description |
+|-------|-------------|
+| [Circuit Breakers](/circuit-breakers/main/) | Introduction to circuit breaker patterns in distributed systems |
+| [Contract Testing](/contract-testing/main/) | Introduction to contract testing and Pact testing |
+| [Smoke Testing](/smoke-testing/main/) | Smoke testing in highly regulated environments |
+| [System Architecture](/system-architecture/main/) | Notes on system architecture design |
+| [Web Services & REST](/web-services/main/) | REST and API design study guide |
+
+## Fun Projects
+
+- [functional-validator](https://github.com/jbiscella/functional-validator) — A functional approach to data validation
+
+## Connect
+
+Feel free to connect on [LinkedIn](https://www.linkedin.com/in/jacopobiscella/) if you have any inquiries or would like to stay updated on my work.

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,3 +1,11 @@
+---
+layout: single
+title: "Smoke Testing in Highly Regulated Environments"
+author_profile: true
+toc: true
+toc_sticky: true
+---
+
 ### **Introduction to Smoke Testing in Highly Regulated Environments**
 
 1. [**Definition and Overview**](#1-definition-and-overview)

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,3 +1,11 @@
+---
+layout: single
+title: "Notes on System Architecture"
+author_profile: true
+toc: true
+toc_sticky: true
+---
+
 ### **Notes of System Architecture**
 
 1. [**Introduction**]()

--- a/web-services/answers.md
+++ b/web-services/answers.md
@@ -1,3 +1,10 @@
+---
+layout: single
+title: "REST API Design Quiz Answers"
+author_profile: true
+toc: false
+---
+
 # Answers to REST API Design Multiple Choice Quizzes
 
 | Question | Quiz 1 | Quiz 2 | Quiz 3 | Quiz 4 |

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,3 +1,11 @@
+---
+layout: single
+title: "Web Services & REST API Design"
+author_profile: true
+toc: true
+toc_sticky: true
+---
+
 # REST and API Design Study Guide
 
 1. [Web Services and REST Architecture](#1-web-services-and-rest-architecture)

--- a/web-services/quiz1.md
+++ b/web-services/quiz1.md
@@ -1,3 +1,10 @@
+---
+layout: single
+title: "REST API Design Quiz 1"
+author_profile: true
+toc: false
+---
+
 # REST API Design Multiple Choice Quiz 1
 
 1. What does REST stand for?

--- a/web-services/quiz2.md
+++ b/web-services/quiz2.md
@@ -1,3 +1,10 @@
+---
+layout: single
+title: "REST API Design Quiz 2"
+author_profile: true
+toc: false
+---
+
 # REST API Design Multiple Choice Quiz 2
 
 1. What is the main difference between PUT and PATCH methods?

--- a/web-services/quiz3.md
+++ b/web-services/quiz3.md
@@ -1,3 +1,10 @@
+---
+layout: single
+title: "REST API Design Quiz 3"
+author_profile: true
+toc: false
+---
+
 # REST API Design Multiple Choice Quiz 3
 
 1. What is the primary purpose of the Vary header in HTTP responses?

--- a/web-services/quiz4.md
+++ b/web-services/quiz4.md
@@ -1,3 +1,10 @@
+---
+layout: single
+title: "REST API Design Quiz 4"
+author_profile: true
+toc: false
+---
+
 # REST API Design Multiple Choice Quiz 4
 
 1. What is the Richardson Maturity Model used for?


### PR DESCRIPTION
## Summary

- Aggiunge configurazione Jekyll con tema **Minimal Mistakes** (skin dark)
- Crea homepage `index.md` con tabella di navigazione e profilo autore
- Aggiunge `_data/navigation.yml` per la barra di navigazione in cima
- Aggiunge front matter Jekyll a tutti i file Markdown esistenti (circuit-breakers, contract-testing, smoke-testing, system-architecture, web-services + quiz)

## Cosa cambia visivamente

- Tema scuro professionale su tutto il sito
- Sidebar sinistra con bio, link LinkedIn e GitHub
- TOC (indice dei contenuti) sticky nella sidebar destra su ogni pagina
- Barra di navigazione in cima con link a tutte le sezioni
- Design responsive per mobile

## Test plan

- [ ] Fare merge su `master`
- [ ] Verificare che GitHub Pages pubblichi correttamente il sito
- [ ] Controllare che tutte le pagine di note siano accessibili
- [ ] Verificare che i file PDF e HTML del CV siano ancora raggiungibili

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo