### PR TITLE
Add HTML CV page without email and phone

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,4 +12,4 @@ main:
       - title: "Web Services & REST"
         url: /web-services/main/
   - title: "CV"
-    url: /ats_resume_with_photo.pdf
+    url: /cv/

--- a/cv.md
+++ b/cv.md
@@ -1,0 +1,146 @@
+---
+layout: single
+title: "Jacopo Biscella"
+subtitle: "Senior Backend Engineer / Software Architect"
+author_profile: true
+toc: true
+toc_sticky: true
+toc_label: "Contents"
+---
+
+**Senior Backend Engineer / Software Architect**
+
+📍 Nyon (VD), Switzerland &nbsp;·&nbsp; 🇮🇹 Italian (native) &nbsp;·&nbsp; 🇬🇧 English (fluent)  
+🔗 [linkedin.com/in/jacopobiscella](https://www.linkedin.com/in/jacopobiscella/)  
+Work Authorization: Swiss B-Permit; British & Italian citizenship
+
+---
+
+## Profile
+
+20+ years building event-driven microservices on the JVM in mission-critical environments (luxury retail, RegTech, travel). Product-minded leader focused on simplicity, testability, observability, and predictable Agile delivery.
+
+---
+
+## Selected Impact
+
+- Built a billing reconciliation capability later measured by Finance at **>$5M/month** recovered revenue.
+- Increased team throughput by **+40%** via pragmatic Agile (Scrum/Kanban, WIP limits, feedback loops).
+- Cut CI/CD provisioning for new warehouses from **>2 weeks to <1 hour** via pipeline automation.
+
+---
+
+## Core Skills
+
+| Area | Skills |
+|------|--------|
+| **Architecture** | Event-driven systems, microservices, domain modeling, API design, resiliency, idempotency |
+| **Backend** | Java, Spring Boot/Framework, Vert.x; JUnit/Mockito/BDD (Cucumber) |
+| **Data & Messaging** | Kafka, Solace; MongoDB, Cassandra, CockroachDB; performance & profiling |
+| **Observability & Ops** | Kubernetes/EKS/OpenShift, Grafana/Prometheus/OpenTelemetry, Docker, GitLab/Jenkins |
+| **Performance & SDK** | JVM tuning, memory management, application profiling; SDK & transversal components |
+| **Technical Leadership** | Mentoring & coaching, Agile delivery (Scrum/Kanban), system design review, hiring |
+
+---
+
+## Experience
+
+### Senior Software Engineer
+**Richemont Group (via ALTEN)** · Meyrin, CH · *Dec 2024 – Present*
+
+Largest Swiss luxury group (Cartier, Van Cleef & Arpels, etc.). Middleware & OMS integration.
+
+- Designed and shipped event-driven microservices on **AWS EKS** bridging Cartier/VCA OMS ↔ SAP, enabling earlier E2E testing and accelerated go-live readiness.
+- Contributed features using **Fluent Commerce Rule SDK** for the new Order Management System (Cartier).
+
+*Tech Stack: Java, Spring Boot, Solace, MongoDB, Fluent Commerce, Docker, GitLab, Kubernetes, Datadog.*
+
+---
+
+### Senior Software Engineer (acting Team Leader)
+**Global Relay** · London, UK · *Jan 2022 – Nov 2024*
+
+RegTech archiving/compliance for 22/25 top global banks; high-scale, regulated workloads.
+
+- Implemented billing reconciliation services on on-prem Kubernetes (Java/Spring, Kafka, CockroachDB): forecasted to recover >$850k/month, **Finance audit confirmed >$5M/month**.
+- Led a cross-functional team of 8 engineers, boosting velocity by **40%** and improving resiliency through SCRUM, BDD, and TDD.
+- Delivered and maintained an **API Gateway** (Spring Cloud Gateway) for REST services maintainability.
+- Integrated Global Relay Message with Meta Business Portal and built the onboarding backend (TypeScript, Next.js, Aerospike).
+- Led memory investigation and strengthened **observability** (logs/traces/metrics) across teams; coordinated cross-team hardening initiatives.
+- Conducted **40+ technical interviews**, set performance goals, and partnered with Product Management to align roadmap and feature prioritization.
+
+*Tech Stack: Java, Spring, Kafka, CockroachDB, Aerospike, Vert.x/RxJava, Cucumber, Docker, Jenkins, K8s, Grafana/Prometheus.*
+
+---
+
+### Senior Software Engineer
+**Ocado Technology** · London, UK · *Oct 2020 – Jan 2022*
+
+Technology company designing cloud orchestration systems for automated robotic warehouses, grocery ecommerce platforms and logistics globally.
+
+- Planned migration from legacy monolith to **microservices** for cloud orchestration of robotic warehouses.
+- Designed CI/CD automation reducing manual setup for new warehouses from **>2 weeks to <1 hour**.
+- Coached Agile adoption; ran architecture education sessions for migration towards AWS/Java.
+
+*Tech Stack: Java, Scala/Akka, Cassandra, Selenium, Cucumber, Docker, K8s, GitLab.*
+
+---
+
+### Senior Software Engineer & Scrum Master
+**Amadeus** · London, UK · *Jul 2015 – Oct 2020*
+
+Global travel IT processing 400M+ transactions daily across airline partners and travel agencies.
+
+- Built a lightweight **AOP framework** and SDK for generating tests from live data.
+- Contributed to a real-time microservice platform enabling event-based interaction with Amadeus data.
+- Led memory investigation efforts, performed **application profiling**, and trained team members on JVM optimization.
+- Scrum Master for globally distributed teams; streamlined dev processes and mentored engineers.
+- Contributed to architectural studies, influencing sprint-focused increments for platform evolution.
+
+*Tech Stack: Java, Groovy, Spring, Kafka, Robot Framework, MongoDB, OpenShift, Docker/K8s, Grafana/Prometheus.*
+
+---
+
+### Co-Founder & Engineering Lead
+**NetProphecy LTD** · London, UK · *Apr 2011 – Jul 2015*
+
+- Managed multiple projects/teams using Agile; led hiring & training for us and clients.
+- Delivered a custom **ERP/CRM system** increasing operational efficiency by **25%** for 5+ SME clients across London and Milan.
+- Hands-on delivery of web applications and mobile apps across the full lifecycle.
+
+*Tech Stack: Java, PHP, MySQL/PostgreSQL, Selenium, Cucumber, Docker/K8s.*
+
+---
+
+### Earlier Roles
+**University of Milan; Mixel S.c.a.r.l.; AIMPES Servizi SRL; Italian public administration** · Italy · *2002 – 2011*
+
+Built ERP and mobile solutions adopted across public sector administrations in Italy (ZK, JBoss, MySQL).
+
+---
+
+## Education
+
+**BSc in Digital Communication** — University of Milan, 2006
+
+---
+
+## Professional Development & Certifications
+
+- MongoDB Developer Training
+- **Udemy** — NestJS Zero to Hero: Modern TypeScript Back-end Development
+- **Udemy** — Masterclass Skills: Team Leadership Skills Masterclass
+- **LinkedIn Learning** — Become a Manager Learning Path
+- **LinkedIn Learning** — Java Memory Management: Garbage Collection, JVM Tuning, and Spotting Memory Leaks
+- **LinkedIn Learning** — Microservices: Security
+- **LinkedIn Learning** — Microservices: Asynchronous Messaging
+- **LinkedIn Learning** — Software Architecture: Breaking a Monolith into Microservices
+
+---
+
+## Keywords (ATS)
+
+**Languages & Frameworks:** Java · Spring Boot/Framework · Vert.x  
+**Platforms & Data:** Kafka · Solace PubSub+ · Kubernetes/EKS/OpenShift · Docker · MongoDB · Cassandra · CockroachDB  
+**Methodologies & Domains:** Microservices · Event-Driven Architecture · DDD · Event Sourcing · CI/CD · Agile/Scrum/Kanban · BDD/TDD · RegTech · Financial Services · Luxury Retail  
+**Tooling & Systems:** OpenTelemetry · Prometheus/Grafana · API Gateway · Fluent Commerce · OMS · AWS EKS

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ On this website you'll find my personal notes and knowledge, shared as a courtes
 
 ## CV
 
-Download my [CV (PDF)](/ats_resume_with_photo.pdf).
+View my [CV](/cv/) online, or [download the PDF](/ats_resume_with_photo.pdf).
 
 ## Connect
 


### PR DESCRIPTION
## Summary

- Aggiunge `cv.md` come pagina Jekyll con tutto il contenuto del CV, **senza email e telefono**
- Aggiorna la navbar per puntare a `/cv/` (HTML) al posto del PDF
- Nella homepage il link al CV ora offre entrambe le opzioni: pagina HTML + download PDF

## Cosa è stato rimosso

| Campo | Valore rimosso |
|-------|---------------|
| Email | jacopo@biscella.com |
| Phone | +41 766 199 009 |

Tutti gli altri dati (LinkedIn, location, work authorization) sono rimasti.

## Test plan

- [ ] Verificare che `/cv/` sia raggiungibile dopo il merge
- [ ] Verificare che email e telefono non compaiano sulla pagina
- [ ] Verificare che il link al PDF nella homepage funzioni ancora
- [ ] Verificare che la navbar mostri il link "CV" corretto

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo