### PR TITLE
Add blog section with Miniature Hobby category

### DIFF
--- a/_posts/2026-04-24-terracotta-army-part-1.md
+++ b/_posts/2026-04-24-terracotta-army-part-1.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: "The Terracotta Army – Part 1: The Strategy"
+date: 2026-04-24 09:00:00 +0200
+categories: hobby technique
+parent: Miniature Hobby
+grand_parent: Blog
+nav_order: 1
+---
+
+# The Terracotta Army – Part 1: The Strategy
+
+It all starts with a suspicion: what if we are prisoners of a dogma? In the world of tabletop miniature painting—from Warhammer 40K centerpieces to historical wargaming—Kolinsky sable is the undisputed king. It's the ultimate "decathlete," an expensive, finely-tuned tool optimized for versatility. On the other side, we have the industrial reliability of brands like **Army Painter** or **Citadel**: brushes built for "failure prevention"—stable, honest, and designed for the average hobbyist's daily grind.
+
+But there is a third way, rooted not in modern hobby shops, but in over 2,000 years of tradition. My project, **The Terracotta Army**, looks toward **Shanlian**, China—a historic center where the craft of brush making has been refined for millennia, home to storied brands like **Zhou Huchen** (est. 1694). Chinese tradition codified the "Four Virtues" of a brush—Tip, Alignment, Roundness, and Resilience—centuries before Western manufacturers formalized similar standards.
+
+With a **$56 wager**, I've bypassed the hobby "elites" to test a different architecture. Instead of 4 expensive "do-it-all" brushes, I've recruited 78 specialists. This isn't about finding a new "best" brush; it's a gamble on **performance granularity**. Can fragmenting quality into 78 specialized units be more efficient than concentrating it into a few elite ones?
+
+1. **Rat Beard (20 pcs - $0.26 ea):** Pure rigid hair with zero reservoir. I'm betting on their stiffness for sub-millimeter detailing—eyes and runes—where a versatile sable might flex too much.
+2. **Zi Hao (Winter Rabbit - 15 pcs - $1.35 ea):** High-tension fibers with incredible shape memory. They sacrifice softness for a rock-steady line during long freehand scrollwork.
+3. **Jian Hao (Mix - 10 pcs - $1.95 ea):** These use porous goat hair for **flow control**. They should give up paint more evenly during glazing, even if they lack a surgical tip.
+4. **Wolf Hair (Weasel - 13 pcs - $0.17 ea):** A cylindrical build that renounces the Western "teardrop" shape to offer lateral stability during edge highlighting.
+5. **Pure Goat (20 pcs - $0.26 ea):** The "Logistics" unit. Sacrificial brushes for messy acrylic washes and metallics, protecting the specialized troops from ruin.
+
+I've acquired an army of 78 units for the price of two standard sets. The challenge is understanding if the **functional decomposition of quality** can outperform the balanced integration of traditional hobby champions.
+
+*In the next episode, we look at the mechanics: why a 20-cent specialist can technically challenge a decathlete in its specific domain.*

--- a/_posts/2026-04-25-terracotta-army-part-2.md
+++ b/_posts/2026-04-25-terracotta-army-part-2.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: "The Terracotta Army – Part 2: Mechanics and Behavior"
+date: 2026-04-25 09:00:00 +0200
+categories: hobby technique
+parent: Miniature Hobby
+grand_parent: Blog
+nav_order: 2
+---
+
+# The Terracotta Army – Part 2: Mechanics and Behavior
+
+Why should a 20-cent brush interest a serious painter? To understand, we have to look past the price tag and into the **micro-mechanics** of the hair. Each fiber behaves differently under the stress of acrylic paint due to its physical structure.
+
+To measure my "army," I'm using three core metrics grounded in hair behavior:
+
+1. **Snapback (Elasticity):** How fast the tip returns to center. This is driven by the diameter and cuticle density of the fiber. High snapback is great for sharp details; low snapback allows for "painterly" blending.
+2. **Stroke Memory (Structural Tension):** How well the hair resists spreading under pressure. Winter Rabbit hair is naturally stiffer, providing a constant width for freehand lines.
+3. **Flow Control (Capillarity):** How evenly the brush releases paint. Porous hairs (like Goat) have a rougher cuticle scale, which "traps" thinned acrylic glazes and releases them slowly, preventing tide marks on flat surfaces like cloaks.
+
+The wager is simple. A **Kolinsky** aims for a perfect triangle, balancing all three metrics at a high level. An **Army Painter** brush occupies a stable, smaller triangle in the center—reliable but unexciting. My **Specialists**, however, are designed to stretch one single axis to the breaking point, sacrificing everything else for a specific peak performance.
+
+By choosing a brush based on its **cuticular structure** rather than its brand name, I'm testing if we can achieve "pro" results through mechanical specialization.
+
+*But how do we handle these tools, and how will I know if they've actually won? Part 3 will set the rules of the game.*

--- a/_posts/2026-04-26-terracotta-army-part-3.md
+++ b/_posts/2026-04-26-terracotta-army-part-3.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: "The Terracotta Army – Part 3: Ergonomics and Protocol"
+date: 2026-04-26 09:00:00 +0200
+categories: hobby technique
+parent: Miniature Hobby
+grand_parent: Blog
+nav_order: 3
+---
+
+# The Terracotta Army – Part 3: Ergonomics and Protocol
+
+Before the first drop of paint hits the plastic, we need to address the "calligraphy gap." Traditional Chinese brushes have long handles designed for vertical movement, quite different from the short, "pencil-grip" handles we use for Warhammer.
+
+## The Ergonomic Trade-off
+
+Let's be honest: for a miniature painter's pinch-grip, a long handle is often a nuisance—banging into lamps, palettes, or the model itself. While it can stabilize tremors in vertical strokes, I will be **modifying the handles to 10-14cm** for better control. This adaptation is part of the test: can these tools be "Westernized" effectively?
+
+## The Testing Protocol
+
+To move from theory to results, I am subjecting the specialists to a four-stage gauntlet against my **Raphaël 8404 (Size 0)** and **Winsor & Newton Series 7** controls:
+
+1. **The Precision Test:** Micro-rune etching on 28mm shoulder pads using the *Rat Beard*.
+2. **The Freehand Test:** Scrollwork and heraldry on a banner using the *Zi Hao*.
+3. **The Glaze Test:** Transitioning a large cloak on a centerpiece model using *Jian Hao* to check for tide marks.
+4. **The Wash Test:** Applying heavy washes to 20 infantry models using the *Pure Goat* to see if the natural hair outperforms synthetic counterparts in pigment distribution.
+
+## Success Criterion
+
+The experiment is a success if the specialist **matches or beats the control brush on its specific task** while costing less than 10% of the control's price.
+
+## Maintenance Note
+
+Each hair type has specific needs—Goat deforms easily, and Rat Beard is incredibly fragile. I will be using a differentiated maintenance routine, which I'll detail in the results. For those looking to join the experiment, these were sourced via **Oopbuy/Taobao**; links will be provided in the next installment.
+
+*The hypothesis is set. The brushes are ready. In the final episode, we see if the Terracotta Army conquers the hobby desk.*

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Blog
+nav_order: 7
+has_children: true
+---
+
+# Blog
+
+Thoughts on engineering, leadership, and hobbies.
+
+---
+
+{% assign sorted_posts = site.posts | sort: 'date' | reverse %}
+{% for post in sorted_posts %}
+### [{{ post.title }}]({{ post.url }})
+*{{ post.date | date: "%B %d, %Y" }}*
+
+{{ post.excerpt }}
+
+---
+{% endfor %}

--- a/blog/miniature-hobby.md
+++ b/blog/miniature-hobby.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Miniature Hobby
+parent: Blog
+nav_order: 1
+---
+
+# Miniature Hobby
+
+Notes and experiments from the hobby desk — painting techniques, brush reviews, and miniature projects.
+
+---
+
+{% assign hobby_posts = site.posts | where_exp: "post", "post.categories contains 'hobby'" | sort: 'date' | reverse %}
+{% for post in hobby_posts %}
+### [{{ post.title }}]({{ post.url }})
+*{{ post.date | date: "%B %d, %Y" }}*
+
+{{ post.excerpt }}
+
+---
+{% endfor %}

--- a/cv.md
+++ b/cv.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: CV
-nav_order: 7
+nav_order: 8
 ---
 
 **Senior Backend Engineer / Software Architect**


### PR DESCRIPTION
## Summary

- Aggiunge `blog/index.md` come landing page del blog (sidebar: nav_order 7)
- Aggiunge `blog/miniature-hobby.md` come pagina categoria, lista automaticamente i post taggati `hobby`
- Aggiunge 3 articoli nella serie **The Terracotta Army** in `_posts/`:
  - Part 1: The Strategy (24 Apr 2026)
  - Part 2: Mechanics and Behavior (25 Apr 2026)
  - Part 3: Ergonomics and Protocol (26 Apr 2026)
- Aggiorna `cv.md` nav_order da 7 a 8 per fare spazio al Blog

## Struttura sidebar dopo il merge

```
Home
Circuit Breakers
Contract Testing
Smoke Testing
System Architecture
Web Services & REST
  ├── Quiz 1–4
  └── Answers
Blog
  └── Miniature Hobby
        ├── Part 1: The Strategy
        ├── Part 2: Mechanics and Behavior
        └── Part 3: Ergonomics and Protocol
CV
```

## Test plan

- [ ] Verificare che "Blog" appaia nella sidebar
- [ ] Verificare che "Miniature Hobby" sia figlio di Blog
- [ ] Verificare che i 3 articoli siano raggiungibili
- [ ] Aggiungere futuri post con `categories: hobby` — appariranno automaticamente

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_