### PR TITLE
Fix blog posts not appearing in sidebar

### DIFF
--- a/blog/miniature-hobby.md
+++ b/blog/miniature-hobby.md
@@ -3,20 +3,9 @@ layout: default
 title: Miniature Hobby
 parent: Blog
 nav_order: 1
+has_children: true
 ---
 
 # Miniature Hobby
 
 Notes and experiments from the hobby desk — painting techniques, brush reviews, and miniature projects.
-
----
-
-{% assign hobby_posts = site.posts | where_exp: "post", "post.categories contains 'hobby'" | sort: 'date' | reverse %}
-{% for post in hobby_posts %}
-### [{{ post.title }}]({{ post.url }})
-*{{ post.date | date: "%B %d, %Y" }}*
-
-{{ post.excerpt }}
-
----
-{% endfor %}

--- a/blog/miniature-hobby/terracotta-army-part-1.md
+++ b/blog/miniature-hobby/terracotta-army-part-1.md
@@ -1,11 +1,10 @@
 ---
 layout: default
-title: "The Terracotta Army – Part 1: The Strategy"
-date: 2026-04-24 09:00:00 +0200
-categories: hobby technique
+title: "Part 1: The Strategy"
 parent: Miniature Hobby
 grand_parent: Blog
 nav_order: 1
+date: 2026-04-24
 ---
 
 # The Terracotta Army – Part 1: The Strategy
@@ -25,3 +24,6 @@ With a **$56 wager**, I've bypassed the hobby "elites" to test a different archi
 I've acquired an army of 78 units for the price of two standard sets. The challenge is understanding if the **functional decomposition of quality** can outperform the balanced integration of traditional hobby champions.
 
 *In the next episode, we look at the mechanics: why a 20-cent specialist can technically challenge a decathlete in its specific domain.*
+
+---
+[Part 2: Mechanics and Behavior →](../terracotta-army-part-2/)

--- a/blog/miniature-hobby/terracotta-army-part-2.md
+++ b/blog/miniature-hobby/terracotta-army-part-2.md
@@ -1,11 +1,10 @@
 ---
 layout: default
-title: "The Terracotta Army – Part 2: Mechanics and Behavior"
-date: 2026-04-25 09:00:00 +0200
-categories: hobby technique
+title: "Part 2: Mechanics and Behavior"
 parent: Miniature Hobby
 grand_parent: Blog
 nav_order: 2
+date: 2026-04-25
 ---
 
 # The Terracotta Army – Part 2: Mechanics and Behavior
@@ -23,3 +22,6 @@ The wager is simple. A **Kolinsky** aims for a perfect triangle, balancing all t
 By choosing a brush based on its **cuticular structure** rather than its brand name, I'm testing if we can achieve "pro" results through mechanical specialization.
 
 *But how do we handle these tools, and how will I know if they've actually won? Part 3 will set the rules of the game.*
+
+---
+[← Part 1: The Strategy](../terracotta-army-part-1/) &nbsp;·&nbsp; [Part 3: Ergonomics and Protocol →](../terracotta-army-part-3/)

--- a/blog/miniature-hobby/terracotta-army-part-3.md
+++ b/blog/miniature-hobby/terracotta-army-part-3.md
@@ -1,11 +1,10 @@
 ---
 layout: default
-title: "The Terracotta Army – Part 3: Ergonomics and Protocol"
-date: 2026-04-26 09:00:00 +0200
-categories: hobby technique
+title: "Part 3: Ergonomics and Protocol"
 parent: Miniature Hobby
 grand_parent: Blog
 nav_order: 3
+date: 2026-04-26
 ---
 
 # The Terracotta Army – Part 3: Ergonomics and Protocol
@@ -34,3 +33,6 @@ The experiment is a success if the specialist **matches or beats the control bru
 Each hair type has specific needs—Goat deforms easily, and Rat Beard is incredibly fragile. I will be using a differentiated maintenance routine, which I'll detail in the results. For those looking to join the experiment, these were sourced via **Oopbuy/Taobao**; links will be provided in the next installment.
 
 *The hypothesis is set. The brushes are ready. In the final episode, we see if the Terracotta Army conquers the hobby desk.*
+
+---
+[← Part 2: Mechanics and Behavior](../terracotta-army-part-2/)


### PR DESCRIPTION
## Problema

Just the Docs non include i file in `_posts/` nella sidebar — funziona solo con pagine normali. I 3 articoli della serie Terracotta Army erano invisibili.

## Soluzione

- Spostati i 3 articoli da `_posts/` a `blog/miniature-hobby/` come pagine normali
- Aggiunto `parent: Miniature Hobby` e `grand_parent: Blog` a ciascuno
- Aggiunti link ← → tra gli episodi in fondo a ogni articolo
- Semplificata `blog/miniature-hobby.md` (non serve più Liquid per listare i post)

## Struttura sidebar dopo il merge

```
Blog
  └── Miniature Hobby
        ├── Part 1: The Strategy
        ├── Part 2: Mechanics and Behavior
        └── Part 3: Ergonomics and Protocol
```

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_