### PR TITLE
Move all content into Blog, simplify homepage

### DIFF
--- a/blog/index.md
+++ b/blog/index.md
@@ -1,22 +1,10 @@
 ---
 layout: default
 title: Blog
-nav_order: 7
+nav_order: 2
 has_children: true
 ---
 
 # Blog
 
-Thoughts on engineering, leadership, and hobbies.
-
----
-
-{% assign sorted_posts = site.posts | sort: 'date' | reverse %}
-{% for post in sorted_posts %}
-### [{{ post.title }}]({{ post.url }})
-*{{ post.date | date: "%B %d, %Y" }}*
-
-{{ post.excerpt }}
-
----
-{% endfor %}
+Engineering notes, leadership insights, and hobby experiments.

--- a/blog/miniature-hobby.md
+++ b/blog/miniature-hobby.md
@@ -2,7 +2,7 @@
 layout: default
 title: Miniature Hobby
 parent: Blog
-nav_order: 1
+nav_order: 7
 has_children: true
 ---
 

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Circuit Breakers
+parent: Blog
 nav_order: 2
 ---
 

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Contract Testing
+parent: Blog
 nav_order: 3
 ---
 

--- a/cv.md
+++ b/cv.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: CV
-nav_order: 8
+nav_order: 3
 ---
 
 **Senior Backend Engineer / Software Architect**

--- a/index.md
+++ b/index.md
@@ -6,38 +6,8 @@ nav_order: 1
 
 # Jacopo Biscella
 
-Senior Backend Engineer / Software Architect based in Nyon, Switzerland.
+Senior Backend Engineer / Software Architect · Nyon, Switzerland
 
 20+ years building event-driven microservices on the JVM in mission-critical environments (luxury retail, RegTech, travel). Focused on simplicity, testability, observability, and predictable Agile delivery.
 
----
-
-## Notes
-
-Personal notes on engineering and leadership, shared as a courtesy for knowledge-sharing with collaborators and the broader tech community.
-
-> These notes have been partially processed with AI and are not necessarily reviewed in depth.
-
-| Topic | Description |
-|-------|-------------|
-| [Circuit Breakers](/circuit-breakers/main/) | Circuit breaker patterns in distributed systems |
-| [Contract Testing](/contract-testing/main/) | Contract testing and Pact testing |
-| [Smoke Testing](/smoke-testing/main/) | Smoke testing in highly regulated environments |
-| [System Architecture](/system-architecture/main/) | System architecture design principles |
-| [Web Services & REST](/web-services/main/) | REST and API design study guide |
-
----
-
-## Fun Projects
-
-- [functional-validator](https://github.com/jbiscella/functional-validator) — A quick proof-of-concept exploring a functional approach to data validation. Built as a learning exercise and not intended for production use.
-
----
-
-## CV
-
-View my [CV](/cv/) online, or [download the PDF](/ats_resume_with_photo.pdf).
-
----
-
-Feel free to connect on [LinkedIn](https://www.linkedin.com/in/jacopobiscella/).
+[Browse the Blog](/blog/) · [View CV](/cv/) · [LinkedIn](https://www.linkedin.com/in/jacopobiscella/)

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Smoke Testing
+parent: Blog
 nav_order: 4
 ---
 

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: System Architecture
+parent: Blog
 nav_order: 5
 ---
 

--- a/web-services/answers.md
+++ b/web-services/answers.md
@@ -2,6 +2,7 @@
 layout: default
 title: Quiz Answers
 parent: Web Services & REST
+grand_parent: Blog
 nav_order: 5
 ---
 

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Web Services & REST
+parent: Blog
 nav_order: 6
 has_children: true
 ---

--- a/web-services/quiz1.md
+++ b/web-services/quiz1.md
@@ -2,6 +2,7 @@
 layout: default
 title: Quiz 1
 parent: Web Services & REST
+grand_parent: Blog
 nav_order: 1
 ---
 

--- a/web-services/quiz2.md
+++ b/web-services/quiz2.md
@@ -2,6 +2,7 @@
 layout: default
 title: Quiz 2
 parent: Web Services & REST
+grand_parent: Blog
 nav_order: 2
 ---
 

--- a/web-services/quiz3.md
+++ b/web-services/quiz3.md
@@ -2,6 +2,7 @@
 layout: default
 title: Quiz 3
 parent: Web Services & REST
+grand_parent: Blog
 nav_order: 3
 ---
 

--- a/web-services/quiz4.md
+++ b/web-services/quiz4.md
@@ -2,6 +2,7 @@
 layout: default
 title: Quiz 4
 parent: Web Services & REST
+grand_parent: Blog
 nav_order: 4
 ---
 


### PR DESCRIPTION
## Cosa cambia

Tutti gli articoli (tech e hobby) sono ora figli di **Blog** nella sidebar.

## Struttura sidebar

```
Home
Blog
  ├── Circuit Breakers
  ├── Contract Testing
  ├── Smoke Testing
  ├── System Architecture
  ├── Web Services & REST
  │     ├── Quiz 1
  │     ├── Quiz 2
  │     ├── Quiz 3
  │     ├── Quiz 4
  │     └── Answers
  └── Miniature Hobby
        ├── Part 1: The Strategy
        ├── Part 2: Mechanics and Behavior
        └── Part 3: Ergonomics and Protocol
CV
```

## Homepage

Semplificata a landing page pulita con 3 link: Blog · CV · LinkedIn.

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_