### PR TITLE
Add Engineering section grouping all IT articles under Blog

### DIFF
--- a/blog/engineering.md
+++ b/blog/engineering.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Engineering
+title: Software Engineering Notes
 parent: Blog
 nav_order: 2
 has_children: true

--- a/blog/engineering.md
+++ b/blog/engineering.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Engineering
+parent: Blog
+nav_order: 2
+has_children: true
+---
+
+# Engineering
+
+Notes on software engineering, system design, and architecture.

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Circuit Breakers
-parent: Engineering
+parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 1
 ---

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Circuit Breakers
-parent: Blog
-nav_order: 2
+parent: Engineering
+grand_parent: Blog
+nav_order: 1
 ---
 
 ### **Introduction to Circuit Breakers**

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Contract Testing
-parent: Engineering
+parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 2
 ---

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Contract Testing
-parent: Blog
-nav_order: 3
+parent: Engineering
+grand_parent: Blog
+nav_order: 2
 ---
 
 # **Introduction to Contract Testing**

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Smoke Testing
-parent: Engineering
+parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 3
 ---

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Smoke Testing
-parent: Blog
-nav_order: 4
+parent: Engineering
+grand_parent: Blog
+nav_order: 3
 ---
 
 ### **Introduction to Smoke Testing in Highly Regulated Environments**

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: System Architecture
-parent: Engineering
+parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 4
 ---

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: System Architecture
-parent: Blog
-nav_order: 5
+parent: Engineering
+grand_parent: Blog
+nav_order: 4
 ---
 
 ### **Notes of System Architecture**

--- a/web-services/answers.md
+++ b/web-services/answers.md
@@ -1,9 +1,7 @@
 ---
 layout: default
 title: Quiz Answers
-parent: Web Services & REST
-grand_parent: Blog
-nav_order: 5
+nav_exclude: true
 ---
 
 # Answers to REST API Design Multiple Choice Quizzes

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Web Services & REST
-parent: Engineering
+parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 5
 ---

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,12 +1,16 @@
 ---
 layout: default
 title: Web Services & REST
-parent: Blog
-nav_order: 6
-has_children: true
+parent: Engineering
+grand_parent: Blog
+nav_order: 5
 ---
 
 # REST and API Design Study Guide
+
+**Quizzes:** [Quiz 1](/web-services/quiz1/) · [Quiz 2](/web-services/quiz2/) · [Quiz 3](/web-services/quiz3/) · [Quiz 4](/web-services/quiz4/) · [Answers](/web-services/answers/)
+
+---
 
 1. [Web Services and REST Architecture](#1-web-services-and-rest-architecture)
    - [Definition of Web Services](#definition-of-web-services)

--- a/web-services/quiz1.md
+++ b/web-services/quiz1.md
@@ -1,9 +1,7 @@
 ---
 layout: default
 title: Quiz 1
-parent: Web Services & REST
-grand_parent: Blog
-nav_order: 1
+nav_exclude: true
 ---
 
 # REST API Design Multiple Choice Quiz 1

--- a/web-services/quiz2.md
+++ b/web-services/quiz2.md
@@ -1,9 +1,7 @@
 ---
 layout: default
 title: Quiz 2
-parent: Web Services & REST
-grand_parent: Blog
-nav_order: 2
+nav_exclude: true
 ---
 
 # REST API Design Multiple Choice Quiz 2

--- a/web-services/quiz3.md
+++ b/web-services/quiz3.md
@@ -1,9 +1,7 @@
 ---
 layout: default
 title: Quiz 3
-parent: Web Services & REST
-grand_parent: Blog
-nav_order: 3
+nav_exclude: true
 ---
 
 # REST API Design Multiple Choice Quiz 3

--- a/web-services/quiz4.md
+++ b/web-services/quiz4.md
@@ -1,9 +1,7 @@
 ---
 layout: default
 title: Quiz 4
-parent: Web Services & REST
-grand_parent: Blog
-nav_order: 4
+nav_exclude: true
 ---
 
 # REST API Design Multiple Choice Quiz 4


### PR DESCRIPTION
## Cosa cambia

Aggiunge la sezione **Engineering** che raggruppa tutti gli articoli IT sotto Blog.

## Sidebar

```
Blog
  ├── Engineering
  │     ├── Circuit Breakers
  │     ├── Contract Testing
  │     ├── Smoke Testing
  │     ├── System Architecture
  │     └── Web Services & REST  ← link ai quiz in cima alla pagina
  └── Miniature Hobby
        ├── Part 1, 2, 3
```

**Nota:** i quiz non appaiono nella sidebar perché Just the Docs supporta max 3 livelli di nesting — sono accessibili via link diretti in cima alla pagina Web Services.

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_