### PR TITLE
Replace auto-TOC with blog-style article listings including previews

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -18,6 +18,27 @@
           <li class="article-item">
             <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
             {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
+            {% if article.description %}
+              <p class="article-preview">{{ article.description }}</p>
+            {% else %}
+              {% assign paragraphs = article.content | split: "\n\n" %}
+              {% assign preview = "" %}
+              {% for para in paragraphs %}
+                {% if preview == "" %}
+                  {% assign stripped = para | strip %}
+                  {% unless stripped == "" or stripped contains "#" or stripped contains "---" %}
+                    {% assign first_char = stripped | slice: 0 %}
+                    {% unless first_char == "|" or first_char == "*" or first_char == "-" or first_char == "!" %}
+                      {% assign is_list_item = stripped | slice: 0, 3 %}
+                      {% unless is_list_item == "1. " or is_list_item == "2. " %}
+                        {% assign preview = stripped | strip_html | truncatewords: 35 %}
+                      {% endunless %}
+                    {% endunless %}
+                  {% endunless %}
+                {% endif %}
+              {% endfor %}
+              {% if preview != "" %}<p class="article-preview">{{ preview }}</p>{% endif %}
+            {% endif %}
           </li>
           {% endfor %}
         </ul>
@@ -42,7 +63,28 @@
         <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
         {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
         {% if article.tags.size > 0 %}
-        <span class="article-tags">{% for tag in article.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
+          <span class="article-tags">{% for tag in article.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
+        {% endif %}
+        {% if article.description %}
+          <p class="article-preview">{{ article.description }}</p>
+        {% else %}
+          {% assign paragraphs = article.content | split: "\n\n" %}
+          {% assign preview = "" %}
+          {% for para in paragraphs %}
+            {% if preview == "" %}
+              {% assign stripped = para | strip %}
+              {% unless stripped == "" or stripped contains "#" or stripped contains "---" %}
+                {% assign first_char = stripped | slice: 0 %}
+                {% unless first_char == "|" or first_char == "*" or first_char == "-" or first_char == "!" %}
+                  {% assign is_list_item = stripped | slice: 0, 3 %}
+                  {% unless is_list_item == "1. " or is_list_item == "2. " %}
+                    {% assign preview = stripped | strip_html | truncatewords: 35 %}
+                  {% endunless %}
+                {% endunless %}
+              {% endunless %}
+            {% endif %}
+          {% endfor %}
+          {% if preview != "" %}<p class="article-preview">{{ preview }}</p>{% endif %}
         {% endif %}
       </li>
       {% endfor %}

--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -1,0 +1,52 @@
+{% if page.title == "Blog" %}
+
+  {% assign categories = site.pages | where: "parent", "Blog" | sort: "nav_order" %}
+  <div class="blog-index">
+    {% for cat in categories %}
+      {% assign cat_articles = site.pages | where: "parent", cat.title %}
+      {% if cat_articles.size > 0 %}
+        {% assign has_dates = false %}
+        {% for a in cat_articles %}{% if a.date %}{% assign has_dates = true %}{% endif %}{% endfor %}
+        {% if has_dates %}
+          {% assign cat_articles = cat_articles | sort: "date" | reverse %}
+        {% else %}
+          {% assign cat_articles = cat_articles | sort: "nav_order" %}
+        {% endif %}
+        <h3 class="category-header"><a href="{{ cat.url | relative_url }}">{{ cat.title }}</a></h3>
+        <ul class="article-list">
+          {% for article in cat_articles %}
+          <li class="article-item">
+            <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
+            {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endfor %}
+  </div>
+
+{% else %}
+
+  {% assign articles = site.pages | where: "parent", page.title %}
+  {% if articles.size > 0 %}
+    {% assign has_dates = false %}
+    {% for a in articles %}{% if a.date %}{% assign has_dates = true %}{% endif %}{% endfor %}
+    {% if has_dates %}
+      {% assign articles = articles | sort: "date" | reverse %}
+    {% else %}
+      {% assign articles = articles | sort: "nav_order" %}
+    {% endif %}
+    <ul class="article-list">
+      {% for article in articles %}
+      <li class="article-item">
+        <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
+        {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
+        {% if article.tags.size > 0 %}
+        <span class="article-tags">{% for tag in article.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+{% endif %}

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,55 @@
+<style>
+  .article-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 1.5rem;
+  }
+
+  .article-item {
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .article-item:last-child {
+    border-bottom: none;
+  }
+
+  .article-title {
+    font-size: 1rem;
+    font-weight: 500;
+  }
+
+  .article-date {
+    font-size: 0.82rem;
+    color: var(--body-text-color-secondary, #6b7280);
+  }
+
+  .article-tags {
+    font-size: 0.78rem;
+    color: var(--body-text-color-secondary, #6b7280);
+    font-style: italic;
+  }
+
+  .blog-index .category-header {
+    margin-top: 1.75rem;
+    margin-bottom: 0.1rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--body-text-color-secondary, #6b7280);
+  }
+
+  .blog-index .category-header a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .blog-index .category-header a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -6,12 +6,8 @@
   }
 
   .article-item {
-    padding: 0.6rem 0;
+    padding: 0.75rem 0;
     border-bottom: 1px solid var(--border-color);
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 0.5rem;
   }
 
   .article-item:last-child {
@@ -32,6 +28,13 @@
     font-size: 0.78rem;
     color: var(--body-text-color-secondary, #6b7280);
     font-style: italic;
+  }
+
+  .article-preview {
+    margin: 0.3rem 0 0;
+    font-size: 0.88rem;
+    color: var(--body-text-color-secondary, #6b7280);
+    line-height: 1.5;
   }
 
   .blog-index .category-header {

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Circuit Breakers
+description: A pattern that prevents cascading failures in distributed systems by short-circuiting calls to a failing service, letting it recover before traffic is restored.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 1

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Contract Testing
+description: A testing approach that verifies each side of a service integration meets the agreed contract, catching integration bugs without requiring both services to be running together.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 2

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Smoke Testing
+description: Notes on smoke testing in regulated environments — fast sanity checks run after a deployment to confirm critical paths still work before deeper verification begins.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 3

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: System Architecture
+description: Study notes covering system design fundamentals — scalability, reliability, trade-offs, and the vocabulary used in architecture discussions and technical interviews.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 4

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Web Services & REST
+description: A study guide on REST principles, HTTP semantics, and API design — including four quizzes to test understanding of the core concepts.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 5


### PR DESCRIPTION
## Summary

- Override `_includes/components/children_nav.html` to replace the just-the-docs auto-generated "TABLE OF CONTENTS" with a blog-style article list including previews
- Blog index groups all articles under category section headers (Software Engineering Notes, Miniature Hobby)
- Category pages sort articles by date descending when dates are present, otherwise by `nav_order`
- Article preview: uses `description` frontmatter when present, otherwise auto-extracts the first prose paragraph from the article content
- Add `description` frontmatter to all 5 SE articles (Circuit Breakers, Contract Testing, Smoke Testing, System Architecture, Web Services & REST)
- Hobby posts and Heikin Ashi article auto-extract their first paragraph (they already have clean prose introductions)
- CSS: article items switch to block layout so the preview sits below title/date; `.article-preview` styled in secondary colour

## Test plan

- [ ] Open `/blog/` — articles grouped by category with title, date, and preview text
- [ ] Open Software Engineering Notes — lists all SE articles with curated `description` previews
- [ ] Open Miniature Hobby — lists the 3 Terracotta Army parts newest first, each with auto-extracted first paragraph as preview
- [ ] Verify sidebar navigation still shows child pages correctly

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_