### PR TITLE
Add article previews to blog index listings

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -18,27 +18,7 @@
           <li class="article-item">
             <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
             {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
-            {% if article.description %}
-              <p class="article-preview">{{ article.description }}</p>
-            {% else %}
-              {% assign paragraphs = article.content | split: "\n\n" %}
-              {% assign preview = "" %}
-              {% for para in paragraphs %}
-                {% if preview == "" %}
-                  {% assign stripped = para | strip %}
-                  {% unless stripped == "" or stripped contains "#" or stripped contains "---" %}
-                    {% assign first_char = stripped | slice: 0 %}
-                    {% unless first_char == "|" or first_char == "*" or first_char == "-" or first_char == "!" %}
-                      {% assign is_list_item = stripped | slice: 0, 3 %}
-                      {% unless is_list_item == "1. " or is_list_item == "2. " %}
-                        {% assign preview = stripped | strip_html | truncatewords: 35 %}
-                      {% endunless %}
-                    {% endunless %}
-                  {% endunless %}
-                {% endif %}
-              {% endfor %}
-              {% if preview != "" %}<p class="article-preview">{{ preview }}</p>{% endif %}
-            {% endif %}
+            {% if article.post_excerpt %}<p class="article-preview">{{ article.post_excerpt }}</p>{% endif %}
           </li>
           {% endfor %}
         </ul>
@@ -65,27 +45,7 @@
         {% if article.tags.size > 0 %}
           <span class="article-tags">{% for tag in article.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
         {% endif %}
-        {% if article.description %}
-          <p class="article-preview">{{ article.description }}</p>
-        {% else %}
-          {% assign paragraphs = article.content | split: "\n\n" %}
-          {% assign preview = "" %}
-          {% for para in paragraphs %}
-            {% if preview == "" %}
-              {% assign stripped = para | strip %}
-              {% unless stripped == "" or stripped contains "#" or stripped contains "---" %}
-                {% assign first_char = stripped | slice: 0 %}
-                {% unless first_char == "|" or first_char == "*" or first_char == "-" or first_char == "!" %}
-                  {% assign is_list_item = stripped | slice: 0, 3 %}
-                  {% unless is_list_item == "1. " or is_list_item == "2. " %}
-                    {% assign preview = stripped | strip_html | truncatewords: 35 %}
-                  {% endunless %}
-                {% endunless %}
-              {% endunless %}
-            {% endif %}
-          {% endfor %}
-          {% if preview != "" %}<p class="article-preview">{{ preview }}</p>{% endif %}
-        {% endif %}
+        {% if article.post_excerpt %}<p class="article-preview">{{ article.post_excerpt }}</p>{% endif %}
       </li>
       {% endfor %}
     </ul>

--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -18,6 +18,27 @@
           <li class="article-item">
             <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
             {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
+            {% if article.description %}
+              <p class="article-preview">{{ article.description }}</p>
+            {% else %}
+              {% assign paragraphs = article.content | split: "\n\n" %}
+              {% assign preview = "" %}
+              {% for para in paragraphs %}
+                {% if preview == "" %}
+                  {% assign stripped = para | strip %}
+                  {% unless stripped == "" or stripped contains "#" or stripped contains "---" %}
+                    {% assign first_char = stripped | slice: 0 %}
+                    {% unless first_char == "|" or first_char == "*" or first_char == "-" or first_char == "!" %}
+                      {% assign is_list_item = stripped | slice: 0, 3 %}
+                      {% unless is_list_item == "1. " or is_list_item == "2. " %}
+                        {% assign preview = stripped | strip_html | truncatewords: 35 %}
+                      {% endunless %}
+                    {% endunless %}
+                  {% endunless %}
+                {% endif %}
+              {% endfor %}
+              {% if preview != "" %}<p class="article-preview">{{ preview }}</p>{% endif %}
+            {% endif %}
           </li>
           {% endfor %}
         </ul>
@@ -42,7 +63,28 @@
         <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
         {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
         {% if article.tags.size > 0 %}
-        <span class="article-tags">{% for tag in article.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
+          <span class="article-tags">{% for tag in article.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
+        {% endif %}
+        {% if article.description %}
+          <p class="article-preview">{{ article.description }}</p>
+        {% else %}
+          {% assign paragraphs = article.content | split: "\n\n" %}
+          {% assign preview = "" %}
+          {% for para in paragraphs %}
+            {% if preview == "" %}
+              {% assign stripped = para | strip %}
+              {% unless stripped == "" or stripped contains "#" or stripped contains "---" %}
+                {% assign first_char = stripped | slice: 0 %}
+                {% unless first_char == "|" or first_char == "*" or first_char == "-" or first_char == "!" %}
+                  {% assign is_list_item = stripped | slice: 0, 3 %}
+                  {% unless is_list_item == "1. " or is_list_item == "2. " %}
+                    {% assign preview = stripped | strip_html | truncatewords: 35 %}
+                  {% endunless %}
+                {% endunless %}
+              {% endunless %}
+            {% endif %}
+          {% endfor %}
+          {% if preview != "" %}<p class="article-preview">{{ preview }}</p>{% endif %}
         {% endif %}
       </li>
       {% endfor %}

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -6,12 +6,8 @@
   }
 
   .article-item {
-    padding: 0.6rem 0;
+    padding: 0.75rem 0;
     border-bottom: 1px solid var(--border-color);
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 0.5rem;
   }
 
   .article-item:last-child {
@@ -32,6 +28,13 @@
     font-size: 0.78rem;
     color: var(--body-text-color-secondary, #6b7280);
     font-style: italic;
+  }
+
+  .article-preview {
+    margin: 0.3rem 0 0;
+    font-size: 0.88rem;
+    color: var(--body-text-color-secondary, #6b7280);
+    line-height: 1.5;
   }
 
   .blog-index .category-header {

--- a/blog/miniature-hobby/terracotta-army-part-1.md
+++ b/blog/miniature-hobby/terracotta-army-part-1.md
@@ -5,6 +5,7 @@ parent: Miniature Hobby
 grand_parent: Blog
 nav_order: 1
 date: 2026-04-24
+post_excerpt: A $56 wager on 78 specialist Chinese brushes — testing whether extreme functional decomposition of quality can outperform a few expensive all-rounders in miniature painting.
 ---
 
 # The Terracotta Army – Part 1: The Strategy

--- a/blog/miniature-hobby/terracotta-army-part-2.md
+++ b/blog/miniature-hobby/terracotta-army-part-2.md
@@ -5,6 +5,7 @@ parent: Miniature Hobby
 grand_parent: Blog
 nav_order: 2
 date: 2026-04-25
+post_excerpt: A dive into hair micro-mechanics — how snapback, stroke memory, and capillary flow explain why a 20-cent specialist brush might beat a $30 Kolinsky at its own game.
 ---
 
 # The Terracotta Army – Part 2: Mechanics and Behavior

--- a/blog/miniature-hobby/terracotta-army-part-3.md
+++ b/blog/miniature-hobby/terracotta-army-part-3.md
@@ -5,6 +5,7 @@ parent: Miniature Hobby
 grand_parent: Blog
 nav_order: 3
 date: 2026-04-26
+post_excerpt: Before the first drop of paint, we address the ergonomic gap and define the protocol — four trials pitting 78 specialists against Raphaël 8404 and Winsor & Newton Series 7 controls.
 ---
 
 # The Terracotta Army – Part 3: Ergonomics and Protocol

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Circuit Breakers
-description: A pattern that prevents cascading failures in distributed systems by short-circuiting calls to a failing service, letting it recover before traffic is restored.
+post_excerpt: A pattern that prevents cascading failures in distributed systems by short-circuiting calls to a failing service, letting it recover before traffic is restored.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 1

--- a/circuit-breakers/main.md
+++ b/circuit-breakers/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Circuit Breakers
+description: A pattern that prevents cascading failures in distributed systems by short-circuiting calls to a failing service, letting it recover before traffic is restored.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 1

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Contract Testing
-description: A testing approach that verifies each side of a service integration meets the agreed contract, catching integration bugs without requiring both services to be running together.
+post_excerpt: A testing approach that verifies each side of a service integration meets the agreed contract, catching integration bugs without requiring both services to be running together.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 2

--- a/contract-testing/main.md
+++ b/contract-testing/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Contract Testing
+description: A testing approach that verifies each side of a service integration meets the agreed contract, catching integration bugs without requiring both services to be running together.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 2

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Smoke Testing
+description: Notes on smoke testing in regulated environments — fast sanity checks run after a deployment to confirm critical paths still work before deeper verification begins.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 3

--- a/smoke-testing/main.md
+++ b/smoke-testing/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Smoke Testing
-description: Notes on smoke testing in regulated environments — fast sanity checks run after a deployment to confirm critical paths still work before deeper verification begins.
+post_excerpt: Notes on smoke testing in regulated environments — fast sanity checks run after a deployment to confirm critical paths still work before deeper verification begins.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 3

--- a/software-engineering/heikin-ashi-monitoring-service.md
+++ b/software-engineering/heikin-ashi-monitoring-service.md
@@ -6,6 +6,7 @@ grand_parent: Blog
 nav_order: 10
 date: 2026-05-10
 tags: [aws, lambda, dynamodb, java, micronaut, bedrock, heikin-ashi, serverless]
+post_excerpt: A serverless monitoring service for equities — computes Heikin Ashi candles, detects patterns, enriches alerts with AI-generated fundamental context, and sends them by email. Designed entirely in a long chat with Claude.
 ---
 
 # Designing a Heikin Ashi Monitoring Service from Scratch

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: System Architecture
-description: Study notes covering system design fundamentals — scalability, reliability, trade-offs, and the vocabulary used in architecture discussions and technical interviews.
+post_excerpt: Study notes covering system design fundamentals — scalability, reliability, trade-offs, and the vocabulary used in architecture discussions and technical interviews.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 4

--- a/system-architecture/main.md
+++ b/system-architecture/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: System Architecture
+description: Study notes covering system design fundamentals — scalability, reliability, trade-offs, and the vocabulary used in architecture discussions and technical interviews.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 4

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Web Services & REST
-description: A study guide on REST principles, HTTP semantics, and API design — including four quizzes to test understanding of the core concepts.
+post_excerpt: A study guide on REST principles, HTTP semantics, and API design — including four quizzes to test understanding of the core concepts.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 5

--- a/web-services/main.md
+++ b/web-services/main.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Web Services & REST
+description: A study guide on REST principles, HTTP semantics, and API design — including four quizzes to test understanding of the core concepts.
 parent: Software Engineering Notes
 grand_parent: Blog
 nav_order: 5


### PR DESCRIPTION
## Summary

- Add `post_excerpt` frontmatter to all 9 articles (5 SE notes, Heikin Ashi, 3 Terracotta Army parts)
- Update `_includes/components/children_nav.html` to render `post_excerpt` below each article title
- Fix: renamed from `description` to `post_excerpt` to avoid conflict with `jekyll-seo-tag` which reads the `description` key
- CSS: article items use block layout so the preview sits below title/date

## Test plan

- [ ] Blog index — each article shows a one-line preview below its title
- [ ] Software Engineering Notes — all 6 articles show their curated summaries
- [ ] Miniature Hobby — 3 Terracotta Army parts show their excerpts, newest first

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_