### PR TITLE
Show blog index as flat reverse-chronological article list

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -1,30 +1,15 @@
 {% if page.title == "Blog" %}
 
-  {% assign categories = site.pages | where: "parent", "Blog" | sort: "nav_order" %}
-  <div class="blog-index">
-    {% for cat in categories %}
-      {% assign cat_articles = site.pages | where: "parent", cat.title %}
-      {% if cat_articles.size > 0 %}
-        {% assign has_dates = false %}
-        {% for a in cat_articles %}{% if a.date %}{% assign has_dates = true %}{% endif %}{% endfor %}
-        {% if has_dates %}
-          {% assign cat_articles = cat_articles | sort: "date" | reverse %}
-        {% else %}
-          {% assign cat_articles = cat_articles | sort: "nav_order" %}
-        {% endif %}
-        <h3 class="category-header"><a href="{{ cat.url | relative_url }}">{{ cat.title }}</a></h3>
-        <ul class="article-list">
-          {% for article in cat_articles %}
-          <li class="article-item">
-            <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
-            {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
-            {% if article.post_excerpt %}<p class="article-preview">{{ article.post_excerpt }}</p>{% endif %}
-          </li>
-          {% endfor %}
-        </ul>
-      {% endif %}
+  {% assign all_articles = site.pages | where: "grand_parent", "Blog" | sort: "date" | reverse %}
+  <ul class="article-list">
+    {% for article in all_articles %}
+    <li class="article-item">
+      <a href="{{ article.url | relative_url }}" class="article-title">{{ article.title }}</a>
+      {% if article.date %}<span class="article-date">{{ article.date | date: "%b %d, %Y" }}</span>{% endif %}
+      {% if article.post_excerpt %}<p class="article-preview">{{ article.post_excerpt }}</p>{% endif %}
+    </li>
     {% endfor %}
-  </div>
+  </ul>
 
 {% else %}
 

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -37,22 +37,5 @@
     line-height: 1.5;
   }
 
-  .blog-index .category-header {
-    margin-top: 1.75rem;
-    margin-bottom: 0.1rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--body-text-color-secondary, #6b7280);
-  }
 
-  .blog-index .category-header a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .blog-index .category-header a:hover {
-    text-decoration: underline;
-  }
 </style>


### PR DESCRIPTION
## Summary

Replace the category-grouped blog index with a single flat list of all articles sorted by date descending:

- Dated posts (Heikin Ashi, Terracotta Army parts) appear first, newest first
- Undated SE notes follow at the end
- Removes unused `.category-header` CSS

## Test plan

- [ ] Open `/blog/` — single flat list, Heikin Ashi (May 10) first, then hobby posts by date, then SE notes at the end
- [ ] Category pages (Software Engineering Notes, Miniature Hobby) unchanged

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_