### PR TITLE
Add H-tchen Mail project to homepage and CLAUDE.md link in Part 4

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,4 +10,10 @@ Senior Backend Engineer / Software Architect · Nyon, Switzerland
 
 20+ years building event-driven microservices on the JVM in mission-critical environments (luxury retail, RegTech, travel). Focused on simplicity, testability, observability, and predictable Agile delivery.
 
+## Personal Projects
+
+**[H-tchen Mail](https://github.com/jbiscella/H-tchen-Mail)** — A serverless daily watchlist monitor that emails me only when a stock forms a meaningful Heikin Ashi pattern. Built on AWS Lambda, Java 25, Micronaut, DynamoDB, and Bedrock. I built this deliberately as a vibe-coding experiment — using Claude as a design and implementation partner throughout — to understand in practice where AI-assisted development works well and where it breaks down. The [four-part series on the blog](/blog/) documents the design conversation, the workflow that emerged, and the production failures the spec couldn't prevent.
+
+---
+
 [Browse the Blog](/blog/) · [View CV](/cv/) · [LinkedIn](https://www.linkedin.com/in/jacopobiscella/)

--- a/software-engineering/from-spec-to-production.md
+++ b/software-engineering/from-spec-to-production.md
@@ -11,7 +11,7 @@ post_excerpt: Eight hours debugging production-only failures on a system that to
 
 # From Spec to Production: What CLAUDE.md Can't Prove
 
-*Part 4 of 6 in the [Heikin Ashi series](#series-navigation).*
+*Part 4 of 6 in the [Heikin Ashi series](#series-navigation). The project's full `CLAUDE.md` spec is [on GitHub](https://github.com/jbiscella/H-tchen-Mail/blob/main/CLAUDE.md).*
 
 The previous three posts described a Heikin Ashi monitoring service, the design conversation that shaped it, and the workflow pattern that produced it. They all live in the design-time half of the project. This post is about what happened when the design met production: the class of failures that the specification could express in principle but had no way to enforce in practice.
 


### PR DESCRIPTION
## Summary

- **Homepage**: adds a "Personal Projects" section describing H-tchen Mail with a link to the GitHub repo and a note that it was built as a vibe-coding / self-learning experiment
- **Part 4 article**: adds a link to the actual `CLAUDE.md` on GitHub directly in the subtitle line

## Test plan

- [ ] Homepage shows Personal Projects section with H-tchen Mail link
- [ ] Part 4 subtitle links to `https://github.com/jbiscella/H-tchen-Mail/blob/main/CLAUDE.md`

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_