### PR TITLE
Add project link to Part 1 and fix homepage series reference

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Senior Backend Engineer / Software Architect · Nyon, Switzerland
 
 ## Personal Projects
 
-**[H-tchen Mail](https://github.com/jbiscella/H-tchen-Mail)** — A serverless daily watchlist monitor that emails me only when a stock forms a meaningful Heikin Ashi pattern. Built on AWS Lambda, Java 25, Micronaut, DynamoDB, and Bedrock. I built this deliberately as a vibe-coding experiment — using Claude as a design and implementation partner throughout — to understand in practice where AI-assisted development works well and where it breaks down. The [four-part series on the blog](/blog/) documents the design conversation, the workflow that emerged, and the production failures the spec couldn't prevent.
+**[H-tchen Mail](https://github.com/jbiscella/H-tchen-Mail)** — A serverless daily watchlist monitor that emails me only when a stock forms a meaningful Heikin Ashi pattern. Built on AWS Lambda, Java 25, Micronaut, DynamoDB, and Bedrock. I built this deliberately as a vibe-coding experiment — using Claude as a design and implementation partner throughout — to understand in practice where AI-assisted development works well and where it breaks down. The [six-part series on the blog](/software-engineering/heikin-ashi-monitoring-service/) documents the design conversation, the workflow that emerged, and the production failures the spec couldn't prevent.
 
 **[functional-validator](https://github.com/jbiscella/functional-validator)** — A lightweight Java validation library built around a fluent builder API: composable predicates, lambda-defined error messages, nested object support, and an `Optional`-returning result. A half-afternoon prototype exploring whether bean validation boilerplate can be replaced with something more readable.
 

--- a/software-engineering/heikin-ashi-monitoring-service.md
+++ b/software-engineering/heikin-ashi-monitoring-service.md
@@ -11,7 +11,7 @@ post_excerpt: A serverless monitoring service for equities — computes Heikin A
 
 # Designing a Heikin Ashi Monitoring Service from Scratch
 
-*Part 1 of 6 in the [Heikin Ashi series](#series-navigation).*
+*Part 1 of 6 in the [Heikin Ashi series](#series-navigation). The project is [on GitHub](https://github.com/jbiscella/H-tchen-Mail).*
 
 I wanted a service that watches a small list of equities, computes Heikin Ashi candles on daily and weekly timeframes, detects a few patterns I care about, and emails me when something interesting happens. Not a trading bot. Not a backtesting platform. A monitoring service for medium-to-long-term investment decisions, with enough fundamental context in the alert to know whether the technical signal is worth a second look.
 


### PR DESCRIPTION
Two small fixes to existing content:

- **Part 1** (`heikin-ashi-monitoring-service.md`): subtitle now links to the H-tchen Mail GitHub repo, matching the convention Part 4 uses for the `CLAUDE.md` link
- **Homepage** (`index.md`): "four-part" → "six-part", and the blog series link now points directly to Part 1 rather than the generic `/blog/` root

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_