### PR TITLE
Name the project in the sentinel article

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,6 +14,8 @@ Senior Backend Engineer / Software Architect · Nyon, Switzerland
 
 **[H-tchen Mail](https://github.com/jbiscella/H-tchen-Mail)** — A serverless daily watchlist monitor that emails me only when a stock forms a meaningful Heikin Ashi pattern. Built on AWS Lambda, Java 25, Micronaut, DynamoDB, and Bedrock. I built this deliberately as a vibe-coding experiment — using Claude as a design and implementation partner throughout — to understand in practice where AI-assisted development works well and where it breaks down. The [project overview](/software-engineering/heikin-ashi-sentinel/) describes what it does; the [six-part engineering series](/software-engineering/heikin-ashi-monitoring-service/) documents the design conversation, the workflow that emerged, and the production failures the spec couldn't prevent.
 
+**[skills-dungeon](https://github.com/jbiscella/skills-dungeon)** — A personal container of skills I extract and accumulate through retrospectives with my AI assistants. Rather than letting the insights from each session evaporate, I feed them back into a structured repository that grows with use.
+
 **[functional-validator](https://github.com/jbiscella/functional-validator)** — A lightweight Java validation library built around a fluent builder API: composable predicates, lambda-defined error messages, nested object support, and an `Optional`-returning result. A half-afternoon prototype exploring whether bean validation boilerplate can be replaced with something more readable.
 
 ---

--- a/software-engineering/heikin-ashi-sentinel.md
+++ b/software-engineering/heikin-ashi-sentinel.md
@@ -16,7 +16,7 @@ not miss the moment a stock I care about turns. So I built a small service
 that does the staring for me and emails me — only when something is worth a
 second look.
 
-It's called the **Heikin Ashi Monitoring Service**. You hand it a handful of
+It's called **[H-tchen Mail](https://github.com/jbiscella/H-tchen-Mail)** — the Heikin Ashi Monitoring Service. You hand it a handful of
 tickers; it watches them once a day and stays silent. Most days nothing
 arrives. When one of them forms a meaningful candle pattern, a single email
 shows up: a chart, the numbers, and a short plain-language note. **The inbox


### PR DESCRIPTION
The sentinel article introduced the project as "the **Heikin Ashi Monitoring Service**" without ever naming it. The first reference is now **[H-tchen Mail](https://github.com/jbiscella/H-tchen-Mail)** — the Heikin Ashi Monitoring Service, linking directly to GitHub.

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_