### PR TITLE
SEO: add meta descriptions and author to all articles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title: "Jacopo Biscella"
-description: "Personal notes on software engineering, system architecture, and testing."
+description: "Software engineering notes on AI-assisted development with Claude Code, Java systems on AWS Lambda, and Heikin Ashi trading tools — by Jacopo Biscella, backend engineer based in Nyon, Switzerland."
+author: Jacopo Biscella
 url: "https://www.jacopobiscella.net"
 baseurl: ""
 repository: "jbiscella/www.jacopobiscella.net"

--- a/index.md
+++ b/index.md
@@ -2,6 +2,7 @@
 layout: home
 title: Home
 nav_order: 1
+description: "Software engineering notes on AI-assisted development with Claude Code, Java systems on AWS Lambda, and Heikin Ashi trading tools — by Jacopo Biscella, backend engineer based in Nyon, Switzerland."
 ---
 
 # Jacopo Biscella

--- a/software-engineering/designing-by-chat-retrospective.md
+++ b/software-engineering/designing-by-chat-retrospective.md
@@ -7,6 +7,7 @@ nav_order: -20260511
 date: 2026-05-11
 tags: [claude, anthropic, ai, design, retrospective, prompt-engineering, epistemology]
 post_excerpt: A 50-turn design conversation reconstructed as a dialogue with an imaginary critic — on premise drift, false architectural confidence, and why CLAUDE.md is not documentation but executable belief.
+description: "A 50-turn design conversation reconstructed as a dialogue with an imaginary critic — on premise drift, false architectural confidence, and why CLAUDE.md is not documentation but executable belief."
 ---
 
 # Designing by Chat: A Retrospective in Dialogue

--- a/software-engineering/from-failures-to-checklists.md
+++ b/software-engineering/from-failures-to-checklists.md
@@ -7,6 +7,7 @@ nav_order: -20260525
 date: 2026-05-25
 tags: [claude, anthropic, ai-assisted-development, checklists, retrospective, discipline]
 post_excerpt: "Every AI-assisted project session generates failures worth keeping. Almost none of them get kept. The final discipline in the series: extracting what went wrong into artifacts the next session can actually use."
+description: "Every AI-assisted project session generates failures worth keeping. Almost none of them get kept. The final discipline in the series: extracting what went wrong into artifacts the next session can actually use."
 ---
 
 # From Failures to Checklists: Closing the Loop

--- a/software-engineering/from-spec-to-production.md
+++ b/software-engineering/from-spec-to-production.md
@@ -7,6 +7,7 @@ nav_order: -20260517
 date: 2026-05-17
 tags: [claude, anthropic, claude-code, aws, lambda, iam, terraform, devops]
 post_excerpt: Eight hours debugging production-only failures on a system that took thirty hours to design and build. A taxonomy of the boundary defects that CLAUDE.md can state but is structurally unable to prove.
+description: "Eight hours debugging production-only failures on a system that took thirty hours to design and build. A taxonomy of the boundary defects that CLAUDE.md can state but is structurally unable to prove."
 ---
 
 # From Spec to Production: What CLAUDE.md Can't Prove

--- a/software-engineering/heikin-ashi-monitoring-service.md
+++ b/software-engineering/heikin-ashi-monitoring-service.md
@@ -7,6 +7,7 @@ nav_order: -20260510
 date: 2026-05-10
 tags: [aws, lambda, dynamodb, java, micronaut, bedrock, heikin-ashi, serverless]
 post_excerpt: A serverless monitoring service for equities — computes Heikin Ashi candles, detects patterns, enriches alerts with AI-generated fundamental context, and sends them by email. Designed entirely in a long chat with Claude.
+description: "A serverless monitoring service for equities — computes Heikin Ashi candles, detects patterns, enriches alerts with AI-generated fundamental context, and sends them by email. Designed entirely in a long chat with Claude."
 ---
 
 # Designing a Heikin Ashi Monitoring Service from Scratch

--- a/software-engineering/heikin-ashi-sentinel.md
+++ b/software-engineering/heikin-ashi-sentinel.md
@@ -7,6 +7,7 @@ nav_order: -20260516
 date: 2026-05-16
 tags: [aws, lambda, java, micronaut, trading, side-project]
 post_excerpt: A serverless daily watchlist watcher that stays silent until a stock forms a meaningful Heikin Ashi pattern — then sends one email with a chart, the numbers, and AI-generated context. The inbox is the interface.
+description: "A serverless daily watchlist watcher that stays silent until a stock forms a meaningful Heikin Ashi pattern — then sends one email with a chart, the numbers, and AI-generated context. The inbox is the interface."
 ---
 
 # A watchlist sentinel that emails me only when a stock does something interesting

--- a/software-engineering/the-operators-manual.md
+++ b/software-engineering/the-operators-manual.md
@@ -7,6 +7,7 @@ nav_order: -20260520
 date: 2026-05-20
 tags: [claude, anthropic, ai-assisted-development, debugging, operations, runbook]
 post_excerpt: "Debugging a running serverless system is not design chat. A third mode — operational chat — has its own rules: one command per turn, hypotheses labelled as hypotheses, file paths verified not guessed. A taxonomy of where my own deployment sessions broke those rules and why it mattered."
+description: "Debugging a running serverless system is not design chat. A third mode — operational chat — has its own rules: one command per turn, hypotheses labelled as hypotheses, file paths verified not guessed. A taxonomy of where my own deployment sessions broke those rules and why it mattered."
 ---
 
 # The Operator's Manual: One Command at a Time

--- a/software-engineering/the-two-claudes-pattern.md
+++ b/software-engineering/the-two-claudes-pattern.md
@@ -7,6 +7,7 @@ nav_order: -20260513
 date: 2026-05-13
 tags: [claude, anthropic, claude-code, workflow, ai-assisted-development, devops, aws]
 post_excerpt: A workflow pattern using two Claude products as distinct roles — chat for architecture and decisions, Claude Code for implementation — with CLAUDE.md as shared memory and a context bundle as the regenerable bridge.
+description: "A workflow pattern using two Claude products as distinct roles — chat for architecture and decisions, Claude Code for implementation — with CLAUDE.md as shared memory and a context bundle as the regenerable bridge."
 ---
 
 # The Two Claudes Pattern: Chat for Thinking, Code for Building

--- a/software-engineering/when-ai-confidence-lies.md
+++ b/software-engineering/when-ai-confidence-lies.md
@@ -7,6 +7,7 @@ nav_order: -20260522
 date: 2026-05-22
 tags: [claude, anthropic, ai-assisted-development, epistemology, debugging, prompt-engineering]
 post_excerpt: AI confidence fails in at least five distinct ways, each with its own recognition signal, its own typical cost, and its own counter-move. A field guide to premise drift, false architectural confidence, speculation as diagnosis, over-generalization from precedent, and confident invention of identifiers.
+description: "AI confidence fails in at least five distinct ways, each with its own recognition signal, its own typical cost, and its own counter-move. A field guide to premise drift, false architectural confidence, speculation as diagnosis, over-generalization from precedent, and confident invention of identifiers."
 ---
 
 # When AI Confidence Lies: A Field Guide


### PR DESCRIPTION
## Summary

Three targeted SEO improvements with no visible content changes:

- **`_config.yml`**: replace generic site description with keyword-rich text naming Claude Code, AWS Lambda, Java, and Heikin Ashi; add `author: Jacopo Biscella` for jekyll-seo-tag
- **`index.md`**: add `description:` frontmatter so the homepage gets a real meta description instead of falling back to the site-wide default
- **All 8 SE articles**: add `description:` field (copied from `post_excerpt`) so jekyll-seo-tag uses the curated excerpt in search result snippets instead of auto-generating from the first paragraph ("Part X of 7 in the Heikin Ashi series")

## Test plan

- [ ] `<meta name="description">` on homepage matches the new description text
- [ ] Each article's `<meta name="description">` matches its `post_excerpt`
- [ ] `<meta name="author">` present on all pages
- [ ] No visible rendering changes on any page

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_