### PR TITLE
SEO: og:image, twitter card, and BlogPosting schema

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -39,3 +39,35 @@
 
 
 </style>
+
+<!-- og:image for social sharing -->
+<meta property="og:image" content="{{ '/assets/images/og-image.jpg' | absolute_url }}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:image" content="{{ '/assets/images/og-image.jpg' | absolute_url }}">
+<meta name="twitter:card" content="summary_large_image">
+
+<!-- BlogPosting / Person schema for blog articles -->
+{% if page.grand_parent == "Blog" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.description | default: page.post_excerpt | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "url": "{{ page.url | absolute_url }}",
+  "author": {
+    "@type": "Person",
+    "name": "Jacopo Biscella",
+    "url": "{{ site.url }}"
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": "Jacopo Biscella",
+    "url": "{{ site.url }}"
+  }{% if page.tags.size > 0 %},
+  "keywords": {{ page.tags | join: ", " | jsonify }}{% endif %}
+}
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary

- **og:image + twitter:card**: added to `head_custom.html` — points to `assets/images/og-image.jpg` (1200×630 recommended). The image file needs to be committed separately before the tag is active; harmless if the file is missing.
- **BlogPosting JSON-LD schema**: injected for every page with `grand_parent: Blog` — covers all 8 SE articles automatically. Includes headline, description, datePublished, url, author, and keywords from frontmatter tags.
- **`assets/images/`**: directory created to receive the og:image file.

## To activate og:image

Commit your profile photo as `assets/images/og-image.jpg` (ideally 1200×630px landscape crop).

## Test plan

- [ ] View source on any SE article — confirm `og:image` meta tag present
- [ ] View source on any SE article — confirm `application/ld+json` script block present with correct title/description/date
- [ ] Validate schema at https://validator.schema.org
- [ ] Once image committed, verify preview on LinkedIn post inspector

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_