### PR TITLE
Change og:image to PNG format

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -41,10 +41,10 @@
 </style>
 
 <!-- og:image for social sharing -->
-<meta property="og:image" content="{{ '/assets/images/og-image.jpg' | absolute_url }}">
+<meta property="og:image" content="{{ '/assets/images/og-image.png' | absolute_url }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta name="twitter:image" content="{{ '/assets/images/og-image.jpg' | absolute_url }}">
+<meta name="twitter:image" content="{{ '/assets/images/og-image.png' | absolute_url }}">
 <meta name="twitter:card" content="summary_large_image">
 
 <!-- BlogPosting / Person schema for blog articles -->


### PR DESCRIPTION
Changes `og:image` and `twitter:image` references from `og-image.jpg` to `og-image.png`. Commit your profile image as `assets/images/og-image.png`.

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_