### PR TITLE
Fix RSS feed: custom Atom feed for blog articles

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,30 @@
+---
+layout: null
+permalink: /feed.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title | xml_escape }}</title>
+  <subtitle>{{ site.description | xml_escape }}</subtitle>
+  <link href="{{ '/feed.xml' | absolute_url }}" rel="self" type="application/atom+xml"/>
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ '/' | absolute_url }}</id>
+  <author>
+    <name>{{ site.author | xml_escape }}</name>
+  </author>
+
+  {% assign articles = site.pages | where: "grand_parent", "Blog" | sort: "date" | reverse %}
+  {% for article in articles %}{% if article.date %}
+  <entry>
+    <title>{{ article.title | xml_escape }}</title>
+    <link href="{{ article.url | absolute_url }}"/>
+    <updated>{{ article.date | date_to_xmlschema }}</updated>
+    <id>{{ article.url | absolute_url }}</id>
+    {% assign excerpt = article.description | default: article.post_excerpt %}
+    {% if excerpt %}<summary type="text">{{ excerpt | xml_escape }}</summary>{% endif %}
+    {% for tag in article.tags %}<category term="{{ tag | xml_escape }}"/>
+    {% endfor %}
+  </entry>
+  {% endif %}{% endfor %}
+</feed>


### PR DESCRIPTION
## Problem

`jekyll-feed` only indexes `_posts/`. All blog articles are pages, so `/feed.xml` was empty.

## Fix

A `feed.xml` at the root with `layout: null` overrides the plugin's output. It queries `site.pages | where: "grand_parent", "Blog" | sort: "date" | reverse` — the same logic as the blog index — producing a proper Atom feed with title, date, summary (from `description` or `post_excerpt`), and tags for each article.

The autodiscovery `<link>` tag in the `<head>` continues to work as before (injected by just-the-docs via `{% feed_meta %}`), now pointing at a feed with actual content.

## Test plan

- [ ] `/feed.xml` returns valid XML with article entries after deploy
- [ ] Validate at https://validator.w3.org/feed/
- [ ] Articles appear in reverse chronological order
- [ ] Each entry has title, link, updated, and summary

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_