### PR TITLE
Fix og:image dimensions and twitter:card type for 640x640 portrait

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -42,10 +42,11 @@
 
 <!-- og:image for social sharing -->
 <meta property="og:image" content="{{ '/assets/images/og-image.png' | absolute_url }}">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="640">
+<meta property="og:image:height" content="640">
 <meta name="twitter:image" content="{{ '/assets/images/og-image.png' | absolute_url }}">
-<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:card" content="summary">
 
 <!-- BlogPosting / Person schema for blog articles -->
 {% if page.grand_parent == "Blog" %}


### PR DESCRIPTION
## Problem

`og:image:width` and `og:image:height` were declared as 1200×630 but the actual image is 640×640. Also `twitter:card` was set to `summary_large_image` which expects a 2:1 landscape image and would crop a square portrait awkwardly.

## Fix

- Correct declared dimensions to 640×640 (matching the actual PNG)
- Add `og:image:type: image/png`
- Switch `twitter:card` to `summary` — uses a square thumbnail, correct for a portrait image

## Note

For optimal LinkedIn and Facebook sharing (1200px wide recommended), the image could be resized/padded to 1200×1200 or cropped to 1200×630. The current 640×640 will work but may appear smaller in some feed previews.

## Test plan

- [ ] Check LinkedIn post inspector: https://www.linkedin.com/post-inspector/
- [ ] Check Twitter card validator
- [ ] Verify `<meta property="og:image:width" content="640">` in page source

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_