### PR TITLE
Add author avatar to site header

### DIFF
--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -1,0 +1,34 @@
+<div class="author-header">
+  <img src="{{ '/assets/images/og-image.jpg' | relative_url }}" alt="Jacopo Biscella" class="author-header-avatar">
+  <span class="author-header-name">Jacopo Biscella</span>
+</div>
+
+<style>
+  .author-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+    padding-right: 1rem;
+  }
+
+  .author-header-avatar {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .author-header-name {
+    font-size: 0.82rem;
+    color: var(--header-child-text-color, #fff);
+    white-space: nowrap;
+  }
+
+  @media (max-width: 50rem) {
+    .author-header-name {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

- Adds `_includes/header_custom.html` with a 30px circular avatar and author name in the top header bar
- Uses the just-the-docs built-in override point — no theme files modified
- Author name hides on narrow screens (≤50rem); avatar remains visible on mobile

## Test plan

- [ ] Header shows circular avatar + "Jacopo Biscella" on the right side
- [ ] On mobile, only the avatar shows (name hidden)
- [ ] No layout breakage with site title and search bar

https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECC15UWfUb3qZchv7u3Uxo)_